### PR TITLE
Alliance and Station Position chooser defaults

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -96,6 +96,7 @@ public class RobotContainer {
 		for (int i = 1; i < 4; i++) {
 			positionChooser.addOption("" + i, i);
 		}
+		positionChooser.setDefaultOption("Default(2)", 2);
 		SmartDashboard.putData("Auto Position", positionChooser);
 
 		configureDriveInputStreams();

--- a/src/main/java/frc/robot/subsystems/autonomous/AutonomousSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/autonomous/AutonomousSubsystem.java
@@ -329,6 +329,12 @@ public class AutonomousSubsystem extends SubsystemBase {
             myAlliance = optAlliance;
         }
 
+        // If we do not have an alliance selected, get one from the Drivers Station if we can...
+        if (myAlliance == null) {
+            if (DriverStation.getAlliance().isPresent()) {
+                myAlliance = DriverStation.getAlliance().get();
+            }
+        }
 
 //      myAlliance = Alliance.Blue;  // Red|Blue
 //      myDSLocation = 3;            // 1|2|3


### PR DESCRIPTION
Added container code to default position (2) to prevent chooser crash.
Added autonomous subsystem code to default the chosen alliance from DriverStation when one is not manually selected.